### PR TITLE
Add dark mode on _quarto.yml

### DIFF
--- a/qmds/_quarto.yml
+++ b/qmds/_quarto.yml
@@ -48,7 +48,9 @@ caption-location: margin
 
 format:
   html:
-    theme: cosmo
+    theme:
+      light: cosmo
+      dark: darkly
     code-fold: show
     code-summary: "Ver el código"
   pdf:


### PR DESCRIPTION
Hi there.
Added dark mode support with a dual-theme configuration (cosmo/darkly).
Check line 51 on _quarto.yml

