### PR TITLE
Add lightbox: true on _quarto.yml

### DIFF
--- a/qmds/_quarto.yml
+++ b/qmds/_quarto.yml
@@ -52,6 +52,7 @@ format:
       light: cosmo
       dark: darkly
     code-fold: show
+    lightbox: true
     code-summary: "Ver el código"
   pdf:
     documentclass: scrreprt


### PR DESCRIPTION
Hi again.
Some images and their text are quite small (no ofense). 
Adding `lightbox: true` in _quarto.yml enables lightbox functionality, allowing readers to click images to view larger versions for better readability.
